### PR TITLE
Allow overriding the `kubeconform` k8s version

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -36,9 +36,11 @@ fi
 
 BUILDKITE_PLUGIN_KUBECONFORM_VERSION="${BUILDKITE_PLUGIN_KUBECONFORM_VERSION:-master}"
 
+BUILDKITE_PLUGIN_KUBE_VERSION="${BUILDKITE_PLUGIN_KUBE_VERSION:-master}"
+
 echo "+++ Running kubeconform on ${#files[@]} files"
 
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "ghcr.io/yannh/kubeconform:$BUILDKITE_PLUGIN_KUBECONFORM_VERSION" -skip ServiceMonitor,Kustomization "${files[@]}"; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "ghcr.io/yannh/kubeconform:$BUILDKITE_PLUGIN_KUBECONFORM_VERSION" -kubernetes-version $BUILDKITE_PLUGIN_KUBE_VERSION -skip ServiceMonitor,Kustomization "${files[@]}"; then
   echo "Kubeconform is ✅ on specified files"
 else
   exit 1

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -40,7 +40,7 @@ BUILDKITE_PLUGIN_KUBE_VERSION="${BUILDKITE_PLUGIN_KUBE_VERSION:-master}"
 
 echo "+++ Running kubeconform on ${#files[@]} files"
 
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "ghcr.io/yannh/kubeconform:$BUILDKITE_PLUGIN_KUBECONFORM_VERSION" -kubernetes-version $BUILDKITE_PLUGIN_KUBE_VERSION -skip ServiceMonitor,Kustomization "${files[@]}"; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "ghcr.io/yannh/kubeconform:$BUILDKITE_PLUGIN_KUBECONFORM_VERSION" -kubernetes-version "$BUILDKITE_PLUGIN_KUBE_VERSION" -skip ServiceMonitor,Kustomization "${files[@]}"; then
   echo "Kubeconform is ✅ on specified files"
 else
   exit 1


### PR DESCRIPTION
`kubeconform` has a -kubernetes-version argument that may need to be overridden depending on the resources being created. 

This passes it down as an environment variable, and defaults to the same as kubeconform: https://github.com/yannh/kubeconform/blob/master/pkg/config/config.go#L66