### PR TITLE
Use our custom kubeconform image from ecr

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -36,7 +36,7 @@ fi
 
 echo "+++ Running kubeconform on ${#files[@]} files"
 
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "997601596833.dkr.ecr.us-east-1.amazonaws.com/main/kubeconform:$BUILDKITE_PLUGIN_KUBECONFORM_VERSION" "${files[@]}"; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "997601596833.dkr.ecr.us-east-1.amazonaws.com/main/kubeconform:{$BUILDKITE_PLUGIN_KUBECONFORM_VERSION}" "${files[@]}"; then
   echo "Kubeconform is ✅ on specified files"
 else
   exit 1

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -34,13 +34,9 @@ if [[ -z ${files:-} ]] ; then
   exit 1
 fi
 
-BUILDKITE_PLUGIN_KUBECONFORM_VERSION="${BUILDKITE_PLUGIN_KUBECONFORM_VERSION:-master}"
-
-BUILDKITE_PLUGIN_KUBE_VERSION="${BUILDKITE_PLUGIN_KUBE_VERSION:-master}"
-
 echo "+++ Running kubeconform on ${#files[@]} files"
 
-if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "ghcr.io/yannh/kubeconform:$BUILDKITE_PLUGIN_KUBECONFORM_VERSION" -kubernetes-version "$BUILDKITE_PLUGIN_KUBE_VERSION" -skip ServiceMonitor,Kustomization "${files[@]}"; then
+if docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "997601596833.dkr.ecr.us-east-1.amazonaws.com/main/kubeconform:$BUILDKITE_PLUGIN_KUBECONFORM_VERSION" "${files[@]}"; then
   echo "Kubeconform is ✅ on specified files"
 else
   exit 1


### PR DESCRIPTION
we have build and push our custom kubeconform image to ecr. 
in order for us to use the image in pipeline, we need to add pos command hook but this plugin repo has that set up already.
Instead of adding post command hook in repo that use the image, we would just update image this plugin use.

NOTE:
Current repo that use this plugin pinned to certain version so this change will not affect.